### PR TITLE
La descripción de ayuda es erroneo

### DIFF
--- a/commands/cve.php
+++ b/commands/cve.php
@@ -14,10 +14,10 @@ class cve extends command
     public function help()
     {
         $chain = 'Uso: Despliega informacion de incidentes de seguridad (CVE)' . "\n";
-        $chain .= '$cve 0000-00000 d1 d2 dN.. . Busqueda por clave CVE, (4 max.)' . "\n";
-        $chain .= '$cve last . Despliega los ultimos 12 CVEs reportados' . "\n";
-        $chain .= '$cve browse <vendor> . Despliega productos del vendedor (Limitado)' . "\n";
-        $chain .= '$cve browse <vendor> <product> . Busca incidentes del producto (10 max.)' . "\n";
+        $chain .= '!cve 0000-00000 d1 d2 dN.. . Busqueda por clave CVE, (4 max.)' . "\n";
+        $chain .= '!cve last . Despliega los ultimos 12 CVEs reportados' . "\n";
+        $chain .= '!cve browse <vendor> . Despliega productos del vendedor (Limitado)' . "\n";
+        $chain .= '!cve browse <vendor> <product> . Busca incidentes del producto (10 max.)' . "\n";
         return $chain;
     }
 

--- a/commands/isdown.php
+++ b/commands/isdown.php
@@ -13,7 +13,7 @@ class isdown extends command
 
     public function help()
     {
-        return 'Uso: $isdown <Valid Domain> . Verifica el estado de un sitio web (Solo HTTP)';
+        return 'Uso: !isdown <Valid Domain> . Verifica el estado de un sitio web (Solo HTTP)';
     }
 
     protected function Request($args)


### PR DESCRIPTION
Se corrigio la descripcion de ayuda de los comandos ISDOWN y CVE,
estos no tenian el COMMANDCHAR correcto (!).